### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/balajirajput96/github-mcp-server-/security/code-scanning/3](https://github.com/balajirajput96/github-mcp-server-/security/code-scanning/3)

To fix the problem, add a `permissions` block at the workflow root (i.e., above the `jobs:` key), specifying only the permissions needed. The minimal starting point for most workflows is `contents: read`, which allows reading repository contents and is sufficient for many CI tasks such as running builds and tests. If artifact upload or release creation, issue or PR modification is required, additional permissions (e.g., `packages: write`, `issues: write`, `pull-requests: write`, `actions: write`) should be scoped only to the relevant jobs. In this case, given the steps shown, only read access to contents is likely required for test/docker jobs, and the release job uploads artifacts but does not touch releases on GitHub directly. Therefore, add a workflow-level permissions block with `contents: read` above the `jobs:` section in `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
