### PR TITLE
fix(ci): build before pruning dev dependencies

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -17,10 +17,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -48,7 +48,7 @@ jobs:
           ./scripts/health-check.sh
       
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -61,7 +61,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Verify deployment configs
         run: |
@@ -113,7 +113,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Check FREE tier documentation
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,27 @@
-# Use official Node.js runtime
-FROM node:18-alpine
+# Build dependencies and TypeScript output before omitting development tooling.
+FROM node:18-alpine AS build
 
-# Set working directory
 WORKDIR /app
 
-# Copy package files
 COPY package*.json ./
+RUN npm ci
 
-# Install dependencies
-RUN npm ci --only=production
-
-# Copy source code
 COPY . .
+RUN npm run build && npm prune --omit=dev
 
-# Build the application
-RUN npm run build
+# Keep the runtime image limited to compiled code and production dependencies.
+FROM node:18-alpine AS runtime
 
-# Create non-root user
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S mcp -u 1001
+WORKDIR /app
+
+COPY --from=build /app/package*.json ./
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+
+RUN addgroup -g 1001 -S nodejs && adduser -S mcp -u 1001
 USER mcp
 
-# Expose port (if needed for future HTTP interface)
+ENV NODE_ENV=production
 EXPOSE 3000
 
-# Set environment
-ENV NODE_ENV=production
-
-# Start the application
 CMD ["npm", "start"]


### PR DESCRIPTION
## Problem

The Docker workflow installed production-only dependencies before running the TypeScript build, so `tsc` was unavailable and the image build failed. The deployment workflow was also blocked because it referenced the retired `actions/upload-artifact@v3`.

## Changes

- Use a multi-stage Docker build that compiles with development dependencies, prunes them afterwards, and ships only compiled output plus production dependencies.
- Update checkout, setup-node, and upload-artifact steps in the deployment workflow to supported v4 actions.

## Validation

- `npm ci`
- `npm run check-secrets -- src/index.ts README.md Dockerfile .github/workflows/auto-deploy.yml`
- `npm run build`
- `git diff --check`

Docker is not installed in the local environment, so the new Dockerfile will receive its final container build validation in the GitHub Actions job.

## Risk and rollback

This only changes build staging and Action versions. Reverting this pull request restores the prior configuration.
