### PR TITLE
fix(docker): prevent prepare before source copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM node:18-alpine AS build
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+# `prepare` runs `npm run build`; install before source is copied, then build explicitly below.
+RUN npm ci --ignore-scripts
 
 COPY . .
 RUN npm run build && npm prune --omit=dev


### PR DESCRIPTION
## Summary
- install dependencies with lifecycle scripts disabled before application source is copied
- run the TypeScript build explicitly after copying the repository
- preserve production dependency pruning in the build stage

## Validation
- `npm ci --ignore-scripts`
- `npm run build`

## Rationale
The Docker build previously ran `npm ci` before copying `tsconfig.json` and source files. The package `prepare` script invokes the TypeScript build, so the image build failed before the source-copy layer. This change defers that build until the source is present.