### PR TITLE
ci: fetch complete history for pull request secret scanning

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Run Gitleaks against the checked-out tree
         uses: gitleaks/gitleaks-action@v2
         env:


### PR DESCRIPTION
## Scope

Fixes the tracked-content Secret Scanning failure observed on Node 24 PR #50.

- Sets `actions/checkout@v5` to `fetch-depth: 0` only for the Gitleaks job.
- Gives Gitleaks access to the pull-request parent commit required for its diff scan.

## Review boundary

This draft changes one workflow line only. It does not merge changes, modify repository settings, rotate secrets, or alter deployment credentials.