### PR TITLE
fix: make secret check CLI self-sufficient

### DIFF
--- a/scripts/check-secrets.js
+++ b/scripts/check-secrets.js
@@ -1,22 +1,56 @@
 #!/usr/bin/env node
 /**
- * Pre-commit hook script to check for exposed secrets
- * Usage: node scripts/check-secrets.js [files...]
- * 
- * This script scans files for exposed credentials and tokens.
- * It can be used as a git pre-commit hook or run manually.
+ * Secret-scanning CLI.
+ * Usage: node scripts/check-secrets.js [file1 file2 ...]
+ * With no explicit files, scans staged files; a clean tree is a successful no-op.
  */
 
-import { readFileSync } from 'fs';
-import { validateForSensitiveData } from '../dist/security-validator.js';
+import { execFileSync, spawnSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 
-const args = process.argv.slice(2);
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const validatorPath = resolve(projectRoot, 'dist/security-validator.js');
 
-if (args.length === 0) {
-  console.error('Usage: node scripts/check-secrets.js <file1> [file2] ...');
-  console.error('');
-  console.error('Example: node scripts/check-secrets.js src/index.ts README.md');
-  process.exit(1);
+if (!existsSync(validatorPath)) {
+  console.log('Built validator not found; running the project build first.');
+  const build = spawnSync('npm', ['run', 'build'], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+    shell: false,
+  });
+  if (build.error) {
+    console.error(`Unable to start the build: ${build.error.message}`);
+    process.exit(1);
+  }
+  if (build.status !== 0) {
+    console.error(`Build failed with exit code ${build.status ?? 'unknown'}.`);
+    process.exit(build.status ?? 1);
+  }
+}
+
+const { validateForSensitiveData } = await import(pathToFileURL(validatorPath).href);
+const explicitFiles = process.argv.slice(2);
+let files = explicitFiles;
+
+if (files.length === 0) {
+  try {
+    const staged = execFileSync(
+      'git',
+      ['diff', '--cached', '--name-only', '--diff-filter=ACMR', '-z'],
+      { cwd: projectRoot, encoding: 'utf8' },
+    );
+    files = staged.split('\0').filter(Boolean);
+  } catch (error) {
+    console.error(`Unable to enumerate staged files: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+if (files.length === 0) {
+  console.log('No staged files to scan.');
+  process.exit(0);
 }
 
 let hasViolations = false;
@@ -27,37 +61,36 @@ const excludedFiles = [
   'check-secrets.js',
 ];
 
-for (const file of args) {
-  // Skip excluded files
+for (const file of files) {
   const fileName = file.split('/').pop();
-  if (excludedFiles.some(excluded => fileName.includes(excluded))) {
+  if (excludedFiles.some((excluded) => fileName.includes(excluded))) {
     console.log(`ℹ️  Skipping ${file} (excluded)`);
     continue;
   }
-  
+
   try {
-    const content = readFileSync(file, 'utf8');
+    const content = readFileSync(resolve(projectRoot, file), 'utf8');
     const result = validateForSensitiveData(content);
-    
+
     if (!result.isValid) {
       hasViolations = true;
       console.error(`\n❌ SECURITY VIOLATION in ${file}:`);
       console.error('━'.repeat(60));
-      
+
       for (const violation of result.violations) {
         console.error(`  Type: ${violation.pattern}`);
         console.error(`  Position: ${violation.position}`);
         console.error(`  Preview: ${violation.match}`);
         console.error('');
       }
-      
+
       console.error('⚠️  This file contains sensitive data that should not be committed!');
       console.error('━'.repeat(60));
     } else {
       console.log(`✓ ${file} - No secrets detected`);
     }
   } catch (error) {
-    console.error(`Error reading ${file}:`, error.message);
+    console.error(`Error reading ${file}: ${error.message}`);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- build the validator automatically when check-secrets runs before a build
- scan staged files when no explicit file list is provided
- resolve files relative to the repository root

## Verification
- npm run clean
- npm run check-secrets
- npm run check-secrets -- package.json
- npm test (14 passed)
- npm run build
- git diff --check

No credentials, workflow permissions, or external calls were added.