### PR TITLE
fix: declare pnpm native build approval

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  unrs-resolver: true


### PR DESCRIPTION
## Summary
- commit a valid pnpm build-policy file for the transitive native resolver dependency
- keep generated lockfile output out of the repository because the existing secret scanner flags registry integrity hashes

## Validation
- pnpm exec tsc --noEmit
- pnpm test
- pnpm run check-secrets