### PR TITLE
fix(docker): install dev deps and ignore prepare so tsc build succeeds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,22 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci --only=production
+# Install ALL dependencies (including devDependencies) so the TypeScript
+# compiler (a devDependency) is available.
+# --ignore-scripts skips the `prepare` lifecycle script (which runs `npm run
+# build` -> `tsc`) because the source code is not copied into the image yet -
+# it is copied in the next step. We run the build explicitly after that.
+RUN npm ci --ignore-scripts
 
 # Copy source code
 COPY . .
 
-# Build the application
+# Build the application (tsc is available from the full install above)
 RUN npm run build
+
+# Prune dev dependencies to keep the production image small.
+# --ignore-scripts prevents the prepare script (tsc) from re-running during prune.
+RUN npm prune --omit=dev --ignore-scripts
 
 # Create non-root user
 RUN addgroup -g 1001 -S nodejs


### PR DESCRIPTION
## Problem
The CI/CD Pipeline `docker` job (run 33619762166) failed on the merge commit d8f5e1f. The Dockerfile ran:

```
RUN npm ci --only=production
```

npm then executed the package `prepare` lifecycle script (`npm run build` -> `tsc`), but the TypeScript compiler is a **devDependency** and is absent under `--only=production`, so `npm ci` exited 1 (`sh: tsc: not found`). All other jobs (test 18/20, Secret Scanning, Auto Deploy, CodeQL) passed.

## Fix
Build the image with dev dependencies present, then prune them:

```
RUN npm ci --ignore-scripts   # install all deps (incl. tsc); skip prepare (source not copied yet)
COPY . .
RUN npm run build             # tsc is available now
RUN npm prune --omit=dev --ignore-scripts  # drop dev deps for a small prod image
```

`--ignore-scripts` on the install prevents `prepare` from running before the source is copied into the image; the build is then run explicitly after `COPY . .`.

## Verification (local, no Docker daemon available here)
- `npm ci` (full), `npm run typecheck`, `npm run build`, `npm test` (16/16) all pass.
- Token-pattern secret scan (the workflow's git-grep checks) clean.
- Simulated every Dockerfile step in order in a clean dir: `npm ci --ignore-scripts` OK, `npm run build` OK, `npm prune --omit=dev --ignore-scripts` OK; typescript/jest pruned; `@modelcontextprotocol/sdk`, `@octokit/rest`, `dotenv` kept; `dist/index.js` executable.

The docker job builds the image with `push: false`, so a green CI run on this PR will confirm the fix.

---
Assisted by [Nebula](https://nebula.gg).